### PR TITLE
Use forward slashes for relative URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Dies sind drei Lösungen zu Testaufgaben eines potentiellen Kunden von mir:
 
 - Aufgabe 1
-  - Ordner [`1a - ES2015`](./1a%20-%20ES2015\index.html), geschrieben in ES2015
-  - Ordner [`1b - Angular`](./1b%20-%20Angular\dist\index.html), geschrieben mit Hilfe von Angular
+  - Ordner [`1a - ES2015`](./1a%20-%20ES2015/index.html), geschrieben in ES2015
+  - Ordner [`1b - Angular`](./1b%20-%20Angular/dist/index.html), geschrieben mit Hilfe von Angular
 
 - Aufgabe 2
   - Ordner `2 - ES2015`, geschrieben in ES2015


### PR DESCRIPTION
Came by way of https://github.com/nteract/nteract/issues/914#issuecomment-381014930, since I could see the issue was the `\` and not the spaces.